### PR TITLE
Change default bg style for relatively-positioned elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ export default {
 - **transitionBgProps**: Properties of the transition function for the background. (Default `{}`)
 - **transitionWindow**: Transition function for the window. (Default `svelte:fade`)
 - **transitionWindowProps**: Properties of the transition function for the window. (Default `{}`)
-- **styleBg**: Style properties of the background. (Default `{}`)
+- **styleBg**: Style properties of the background. (Default `{top: 0, left: 0}`)
 - **styleWindow**: Style properties of the modal window. (Default `{}`)
 - **styleContent**: Style properties of the modal content. (Default `{}`)
 

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -10,7 +10,7 @@
   export let transitionBgProps = { duration: 250 };
   export let transitionWindow = transitionBg;
   export let transitionWindowProps = transitionBgProps;
-  export let styleBg = {};
+  export let styleBg = {top: 0, left:0};
   export let styleWindow = {};
   export let styleContent = {};
   export let setContext = baseSetContext;


### PR DESCRIPTION
When a modal is created inside a relatively-positioned element, the modal background is offset and inside the relatively positioned parent, making it look weird. This commit fixes that and should make it less confusing for people trying to use the library.