### PR TITLE
Dispatch open and close events

### DIFF
--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -83,7 +83,7 @@
     };
     onClosed = () => {
       callback.onClosed || toVoid;
-      dispatch('close')
+      dispatch('close');
     };
   };
 

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -1,6 +1,9 @@
 <script>
   import * as svelte from 'svelte';
   import { fade } from 'svelte/transition';
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
 
   const baseSetContext = svelte.setContext;
   const SvelteComponent = svelte.SvelteComponent;
@@ -74,8 +77,14 @@
     state = { ...defaultState, ...options };
     onOpen = callback.onOpen || toVoid;
     onClose = callback.onClose || toVoid;
-    onOpened = callback.onOpened || toVoid;
-    onClosed = callback.onClosed || toVoid;
+    onOpened = () => {
+      callback.onOpened || toVoid;
+      dispatch('open');
+    };
+    onClosed = () => {
+      callback.onClosed || toVoid;
+      dispatch('close')
+    };
   };
 
   const close = (callback = {}) => {

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -75,15 +75,21 @@
     Component = NewComponent;
     props = newProps;
     state = { ...defaultState, ...options };
-    onOpen = callback.onOpen || toVoid;
-    onClose = callback.onClose || toVoid;
-    onOpened = () => {
-      callback.onOpened || toVoid;
-      dispatch('open');
+    onOpen = (event) => {
+      if (callback.onOpen) callback.onOpen(event);
+      dispatch('opening');
+    },
+    onClose = (event) => {
+      if (callback.onClose) callback.onClose(event);
+      dispatch('closing');
+    },
+    onOpened = (event) => {
+      if (callback.onOpened) callback.onOpened(event);
+      dispatch('opened');
     };
-    onClosed = () => {
-      callback.onClosed || toVoid;
-      dispatch('close');
+    onClosed = (event) => {
+      if (callback.onClosed) callback.onClosed(event);
+      dispatch('closed');
     };
   };
 


### PR DESCRIPTION
It could be handy to dispatch opening, opened, closing and closed events to the parent component. I understand I could use a callback in the component that calls open(), but there is a convenience to using events. For example:

```svelte
<script>
    import Modal from "svelte-simple-modal";

    let open = false;
    let scrollbarWidth = calcScollbarWidth();

    function handleOpened() { ... }

    function handleClosed() { ... }
</script>

<Modal on:opened={handleOpened} on:closed={handleClosed}>
    <body style={open ? 'overflow: hidden;' : 'overflow: auto;'}>
        <div style={open ? `margin-right: ${scrollBarWidth}px;` : ''}>
            ...
        </div>
    </body>
</Modal>
```