### PR TITLE
Update on:open and on:close to match actual events emitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ The `<Modal />` component accepts the following properties:
 
 The `<Modal />` component dispatches the following events:
 
-- `open`: dispatched when the modal window starts to open.
+- `opening`: dispatched when the modal window starts to open.
 - `opened`: dispatched when the modal window opened.
-- `close`: dispatched when the modal window starts to close.
+- `closing`: dispatched when the modal window starts to close.
 - `closed`: dispatched when the modal window closed.
 
 Alternatively, you can listen to those events via callbacks passed to [`open()`](#open) and [`close()`](#close).
@@ -173,9 +173,9 @@ You can access the context via `getContext('simple-modal')`. It exposes the foll
 
   ```javascript
   {
-    onOpen: () => { /* modal window starts to open */ },
+    onOpening: () => { /* modal window starts to open */ },
     onOpened: () => { /* modal window opened */ },
-    onClose: () => { /* modal window starts to close */ },
+    onClosing: () => { /* modal window starts to close */ },
     onClosed: () => { /* modal window closed */ },
   }
   ```


### PR DESCRIPTION
Was trying to use these methods when I realized their names had been changed. This just updates the README to reflect what the events are called (specifically to `on:opening` and `on:closing`)