### PR TITLE
remove fixed positioning from <body>

### DIFF
--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -168,7 +168,6 @@
     scrollY = window.scrollY;
     prevBodyPosition = document.body.style.position;
     prevBodyOverflow = document.body.style.overflow;
-    document.body.style.position = 'fixed';
     document.body.style.top = `-${scrollY}px`;
     document.body.style.overflow = 'hidden';
   };

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -67,7 +67,6 @@
   let cssCloseButton;
   let currentTransitionBg;
   let currentTransitionWindow;
-  let prevBodyPosition;
   let prevBodyOverflow;
 
   const camelCaseToDash = str => str
@@ -166,14 +165,12 @@
 
   const disableScroll = () => {
     scrollY = window.scrollY;
-    prevBodyPosition = document.body.style.position;
     prevBodyOverflow = document.body.style.overflow;
     document.body.style.top = `-${scrollY}px`;
     document.body.style.overflow = 'hidden';
   };
 
   const enableScroll = () => {
-    document.body.style.position = prevBodyPosition || '';
     document.body.style.top = '';
     document.body.style.overflow = prevBodyOverflow || '';
     window.scrollTo(0, scrollY);


### PR DESCRIPTION
I found that `position: fixed` on the root page <body> in some cases causes page contents to shift left under the modal when the modal is opened (and shift back into place when it is closed).

Unfortunately I have been unable to replicate the issue in a sandbox to identify the root cause but I am seeing the issue on several sites where my svelte web component is deployed.

Simply leaving the `<body position>` as-is seems to fix the issue with no negative or unintended consequences.