### PR TITLE
Change outer click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.2
+
+- Improve outer click handling and avoid accidental closing of the modal (#39)
+
 # 0.10.1
 
 - Harmonize `on:open`/`on:opening` and `on:close`/`on:closing` event (#33 and #34). Note, `on:opening` and `on:closing` are still being dispatched for backward compatibility but they will be remove in future versions so please switch over to `on:open` and `on:close`.

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -69,6 +69,7 @@
   let currentTransitionWindow;
   let prevBodyPosition;
   let prevBodyOverflow;
+  let outerClickTarget;
 
   const camelCaseToDash = str => str
     .replace(/([a-zA-Z])(?=[A-Z])/g, '$1-').toLowerCase();
@@ -153,11 +154,17 @@
     }
   };
 
-  const handleOuterClick = (event) => {
+  const handleOuterMousedown = (event) => {
     if (
-      state.closeOnOuterClick && event.button === 0 && (
+      state.closeOnOuterClick && (
         event.target === background || event.target === wrap
       )
+    ) outerClickTarget = event.target;
+  };
+
+  const handleOuterMouseup = (event) => {
+    if (
+      state.closeOnOuterClick && event.target === outerClickTarget
     ) {
       event.preventDefault();
       close();
@@ -314,7 +321,8 @@
 {#if Component}
   <div
     class="bg"
-    on:mousedown={handleOuterClick}
+    on:mousedown={handleOuterMousedown}
+    on:mouseup={handleOuterMouseup}
     bind:this={background}
     transition:currentTransitionBg={state.transitionBgProps}
     style={cssBg}

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -155,7 +155,7 @@
 
   const handleOuterClick = (event) => {
     if (
-      state.closeOnOuterClick && (
+      state.closeOnOuterClick && event.button === 0 && (
         event.target === background || event.target === wrap
       )
     ) {
@@ -314,7 +314,7 @@
 {#if Component}
   <div
     class="bg"
-    on:click={handleOuterClick}
+    on:mousedown={handleOuterClick}
     bind:this={background}
     transition:currentTransitionBg={state.transitionBgProps}
     style={cssBg}


### PR DESCRIPTION
I was running into an issue where the modal would accidentally close if I mousedown on the modal and mouseup outside of the modal. For example, if I had a text box and wanted to copy my text inside the modal, I might accidentally close the modal and lose my text. I found this issue in Chrome, Edge, and Safari (not Firefox). 
Even before the change, any mousedown outside the modal and mouseup inside the modal would still close the modal on mouseup. This is still the same after the change, except the modal would close at mousedown, giving no opportunity to mouseup in the modal.

[Here](https://svelte.dev/repl/940fe56013644eed8aee574ddeda85d6?version=3.38.2) is the change on the demo.

Original issue:
![60ae229b69146199448253](https://user-images.githubusercontent.com/44045645/119644959-5dd5b300-bdd2-11eb-9466-5343194e6cd1.gif)


Thanks!