### PR TITLE
Fix: Only call enable/disableScroll on open/close

### DIFF
--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -109,6 +109,7 @@
     Component = bind(NewComponent, newProps);
     state = { ...defaultState, ...options };
     updateStyleTransition();
+    disableScroll();
     onOpen = (event) => {
       if (callback.onOpen) callback.onOpen(event);
       dispatch('open');
@@ -133,6 +134,7 @@
     onClose = callback.onClose || onClose;
     onClosed = callback.onClosed || onClosed;
     Component = null;
+    enableScroll();
   };
 
   const handleKeydown = (event) => {
@@ -202,14 +204,6 @@
 
   svelte.onDestroy(() => {
     close();
-  });
-
-  svelte.afterUpdate(() => {
-    if (Component) {
-      disableScroll();
-    } else {
-      enableScroll();
-    }
   });
 </script>
 

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -194,16 +194,24 @@
 
   setContext(key, { open, close });
 
+  let isMounted = false;
+
   $: {
-    if (isFunction(show)) {
-      open(show);
-    } else {
-      close();
+    if (isMounted) {
+      if (isFunction(show)) {
+        open(show);
+      } else {
+        close();
+      }
     }
   }
 
   svelte.onDestroy(() => {
-    close();
+    if (isMounted) close();
+  });
+
+  svelte.onMount(() => {
+    isMounted = true;
   });
 </script>
 


### PR DESCRIPTION
## Background
I have a Svelte app that keeps track of a variable in App, and passes it down to multiple child components. When the variable is updated I'm encountering some odd scrolling behaviour.

## Observed Behaviour
I've created a minimal REPL example with a basic counter variable: https://svelte.dev/repl/24df7129ba5c45c4903f87f9a8d0d36e?version=3.38.3

Two odd behaviours occur (seen in latest Firefox/Chrome/Edge on Windows 10):
1. If the page is scrolled before the counter is incremented, the page jumps back to the top
2. If the counter is incremented while the pop-up is open, scrolling remains disabled after the modal is closed.

## Cause
Svelte will update the Modal component when the counter is updated, even if the state of the Modal itself hasn't changed. Because `open` and `close` are called in `svelte.afterUpdate`, this means `enableScroll` or `disableScroll` may be called multiple times without the modal actually opening or closing.

This means:
1. When the counter is updated while the pop-up is closed `enableScroll` is called, which in turn calls `window.scrollTo(0, scrollY)` where scrollY is undefined and treated as 0.
2. When the counter is updated while the pop-up is open `disableScroll` gets run a second time, which means the cached values (like previousBodyPosition) get overwritten with the identical current values. This means e.g. when the modal is closed the the body keeps `position: fixed`.

## Fix

Explicitly calling disable/enable during open/close fixes the issue for me. I do appreciate the elegance of using `afterUpdate` but it seems Svelte has other ideas :)