### PR TITLE
Fix bind type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "types/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 0",
-    "build": "rm -rf lib && rm -rf types && rollup -c",
+    "build": "rm -rf lib && rm -rf types && rollup -c && tsc src/bind.js --allowJs --declaration --emitDeclarationOnly --outDir types",
     "precommit": "NODE_ENV=production lint-staged; npm run lint",
     "prepare": "npm run lint && npm run build",
     "prerelease": "npm run lint; rm -f dist.zip; npm run build; zip dist.zip lib/* src/* types/*",

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -1,25 +1,9 @@
-<script context="module">
-  /**
-   * Create a Svelte component with props bound to it.
-   * @type {(component: Component, props: Record<string, any>) => Component}
-   */
-  export function bind(Component, props = {}) {
-    return function ModalComponent(options) {
-      return new Component({
-        ...options,
-        props: {
-          ...props,
-          ...options.props,
-        },
-      });
-    };
-  }
-</script>
-
 <script>
   import * as svelte from 'svelte';
   import { fade } from 'svelte/transition';
   import { createEventDispatcher } from 'svelte';
+
+  import bind from './bind';
 
   const dispatch = createEventDispatcher();
 

--- a/src/bind.js
+++ b/src/bind.js
@@ -1,0 +1,17 @@
+/**
+ * Create a Svelte component with props bound to it.
+ * @type {(component: Component, props: Record<string, any>) => Component}
+ */
+function bind(Component, props = {}) {
+  return function ModalComponent(options) {
+    return new Component({
+      ...options,
+      props: {
+        ...props,
+        ...options.props,
+      },
+    });
+  };
+}
+
+export default bind;

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
-export { bind, default, default as Modal } from './Modal.svelte';
+export { default as bind } from './bind';
+export { default, default as Modal } from './Modal.svelte';

--- a/types/Modal.svelte.d.ts
+++ b/types/Modal.svelte.d.ts
@@ -1,14 +1,6 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from 'svelte';
 
-/**
- * Create a Svelte component with props bound to it.
- */
-export type bind = (
-  component: Component,
-  props: Record<string, any>
-) => Component;
-
 export interface ModalProps {
   /**
    * Svelte component to be shown as the modal

--- a/types/bind.d.ts
+++ b/types/bind.d.ts
@@ -1,0 +1,6 @@
+export default bind;
+/**
+ * Create a Svelte component with props bound to it.
+ * @type {(component: Component, props: Record<string, any>) => Component}
+ */
+declare function bind(Component: any, props?: Record<string, any>): any;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,3 @@
-export { default as bind, bind } from './Modal.svelte';
-export { default, bind } from './Modal.svelte';
-export { default as Modal, bind } from './Modal.svelte';
+export { default as bind } from './bind';
+export { default } from './Modal.svelte';
+export { default as Modal } from './Modal.svelte';


### PR DESCRIPTION
Fixes #70 

The problem seems to be with trying to use sveld for type generation outside a svelte component, i.e., the `bind` function in the "module" script at the top of src/Modal.svelte

The issue is twofold. 

First, sveld is creating the bind function's type as, well, a type:
<img width="464" alt="Screen Shot 2022-04-22 at 11 42 27 AM" src="https://user-images.githubusercontent.com/344803/164748585-adcf5e9b-37ce-46f8-ac71-8f5b2137e6cd.png">
When what we need is a function:
<img width="638" alt="Screen Shot 2022-04-22 at 11 45 20 AM" src="https://user-images.githubusercontent.com/344803/164749077-e293229a-b828-4b1e-84ac-a8b5c925876c.png">

Second, the the default export from Modal.svelte is being set as both bind and Modal.
<img width="492" alt="Screen Shot 2022-04-22 at 11 47 56 AM" src="https://user-images.githubusercontent.com/344803/164749494-39d7fe9e-f6f9-4764-9d91-82e44210cf3e.png">
This is what causes the "Value of type 'typeof Modal' is not callable" IDE error.
<img width="872" alt="Screen Shot 2022-04-22 at 11 56 24 AM" src="https://user-images.githubusercontent.com/344803/164751014-7e14e8b9-38ea-4994-a8ef-2bf62612bda1.png">
When what we want is separate export for bind:
<img width="436" alt="Screen Shot 2022-04-22 at 11 52 18 AM" src="https://user-images.githubusercontent.com/344803/164750245-ac5b6f89-d190-44a3-9b0f-5873dfaffc3f.png">

Please review the changes and ask any questions. If there is a way to accomplish this with only sveld then please disregard and advise.

Thanks!


