### PR TITLE
make tabindex lower case

### DIFF
--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -326,7 +326,7 @@
     if (Component && event.key === 'Tab' && !state.disableFocusTrap) {
       // trap focus
       const nodes = modalWindow.querySelectorAll('*');
-      const tabbable = Array.from(nodes).filter((node) => node.tabindex >= 0);
+      const tabbable = Array.from(nodes).filter((node) => node.tabindex >= 0).sort((a,b) => a.tabIndex - b.tabIndex);
 
       let index = tabbable.indexOf(document.activeElement);
       if (index === -1 && event.shiftKey) index = 0;

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -326,7 +326,7 @@
     if (Component && event.key === 'Tab' && !state.disableFocusTrap) {
       // trap focus
       const nodes = modalWindow.querySelectorAll('*');
-      const tabbable = Array.from(nodes).filter((node) => node.tabIndex >= 0);
+      const tabbable = Array.from(nodes).filter((node) => node.tabindex >= 0);
 
       let index = tabbable.indexOf(document.activeElement);
       if (index === -1 && event.shiftKey) index = 0;

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -326,7 +326,7 @@
     if (Component && event.key === 'Tab' && !state.disableFocusTrap) {
       // trap focus
       const nodes = modalWindow.querySelectorAll('*');
-      const tabbable = Array.from(nodes).filter((node) => node.tabindex >= 0).sort((a,b) => a.tabIndex - b.tabIndex);
+      const tabbable = Array.from(nodes).filter((node) => node.tabIndex >= 0).sort((a,b) => a.tabIndex - b.tabIndex);
 
       let index = tabbable.indexOf(document.activeElement);
       if (index === -1 && event.shiftKey) index = 0;

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -326,7 +326,8 @@
     if (Component && event.key === 'Tab' && !state.disableFocusTrap) {
       // trap focus
       const nodes = modalWindow.querySelectorAll('*');
-      const tabbable = Array.from(nodes).filter((node) => node.tabIndex >= 0).sort((a,b) => a.tabIndex - b.tabIndex);
+      const tabbable = Array.from(nodes).filter((node) => node.tabIndex >= 0)
+        .sort((a, b) => a.tabIndex - b.tabIndex);
 
       let index = tabbable.indexOf(document.activeElement);
       if (index === -1 && event.shiftKey) index = 0;


### PR DESCRIPTION
## Background

Hi, I have a Svelte App with multiple input fields inside the modal. I cannot use tabindex to switch between inputs. This is because the tabindex attribute should be written in lower case (see https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex).

## Currently Observed Behavior

I cannot use tabindex to switch between inputs. 
Demo: https://svelte.dev/repl/f2da168bd00b4ea08acc63c5719b67d9?version=3.48.0

## New Behavior

I can use tabindex to switch betwwen inputs.
Demo: https://svelte.dev/repl/f15d53f9987d4eb4afe7d01db72a2f24?version=3.48.0
