### PR TITLE
Add 'type="button"' to prevent form submission

### DIFF
--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -461,6 +461,7 @@
               aria-label="Close modal"
               on:click={close}
               style={cssCloseButton}
+              type="button"
             />
           {/if}
         {/if}


### PR DESCRIPTION
## Background

See [#83](https://github.com/flekschas/svelte-simple-modal/issues/83)

## Currently Observed Behavior

When `<Modal />` is wrapped by a `<form />`, clicking on the default close button submits the form

**Demo:** https://svelte.dev/repl/dd87925ed7a64f08936257414fd63841?version=3.48.0

## New Behavior

With the change, the close button has not default behavior and, thus, will not submit the form

**Demo:** https://svelte.dev/repl/7e3efb8138314975ad246a3a575a450b?version=3.48.0
