### PR TITLE
Fix: force "instant" scrollTo behavior

### DIFF
--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -108,9 +108,9 @@
 
   /**
    * Scrolling behaviour after modal closes
-   * @type {"instant" | "smooth"}
+   * @type {'instant' | 'smooth' | 'auto'}
    */
-  export let scrollBehaviour = undefined;
+  export let scrollBehaviour = 'auto';
 
   /**
    * Whether to close the modal upon an outside mouse click or not

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -107,12 +107,6 @@
   export let closeOnEsc = true;
 
   /**
-   * Scrolling behaviour after modal closes
-   * @type {'instant' | 'smooth' | 'auto'}
-   */
-  export let scrollBehaviour = 'auto';
-
-  /**
    * Whether to close the modal upon an outside mouse click or not
    * @type {boolean}
    */
@@ -438,7 +432,7 @@
     window.scrollTo({
       top: scrollY,
       left: 0,
-      behavior: scrollBehaviour,
+      behavior: "instant",
     });
   };
 

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -107,6 +107,12 @@
   export let closeOnEsc = true;
 
   /**
+   * Scrolling behaviour after modal closes
+   * @type {"instant" | "smooth"}
+   */
+  export let scrollBehaviour = undefined;
+
+  /**
    * Whether to close the modal upon an outside mouse click or not
    * @type {boolean}
    */
@@ -429,7 +435,11 @@
     document.body.style.top = '';
     document.body.style.overflow = prevBodyOverflow || '';
     document.body.style.width = prevBodyWidth || '';
-    window.scrollTo(0, scrollY);
+    window.scrollTo({
+      top: scrollY,
+      left: 0,
+      behavior: scrollBehaviour,
+    });
   };
 
   /**

--- a/types/Modal.svelte.d.ts
+++ b/types/Modal.svelte.d.ts
@@ -129,6 +129,12 @@ export interface ModalProps {
   closeOnEsc?: boolean;
 
   /**
+   * Scrolling behaviour after modal closes
+   * @default undefined
+   */
+  scrollBehaviour?: 'instant' | 'smooth';
+
+  /**
    * Whether to close the modal upon an outside mouse click or not
    * @default true
    */

--- a/types/Modal.svelte.d.ts
+++ b/types/Modal.svelte.d.ts
@@ -129,12 +129,6 @@ export interface ModalProps {
   closeOnEsc?: boolean;
 
   /**
-   * Scrolling behaviour after modal closes
-   * @default undefined
-   */
-  scrollBehaviour?: 'instant' | 'smooth';
-
-  /**
    * Whether to close the modal upon an outside mouse click or not
    * @default true
    */


### PR DESCRIPTION
## Background

I am using this package for rendering forms in modal and it has currently one annoying issue with forced smooth scroll.

## Currently Observed Behavior

I am observing forced smooth scroll in Google Chrome (tested only there) when package scrolls back the page to previous saved position after modal is closed.

## New Behavior

Added option to customize `window.scrollTo()` scroll behavior that can overwrite/force it.
