### PR TITLE
Svelte 5 upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "typescript": "^5.1.3"
       },
       "peerDependencies": {
-        "svelte": "^3.30.0 || ^4.0.0"
+        "svelte": "^5.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/flekschas/svelte-simple-modal#readme",
   "peerDependencies": {
-    "svelte": "^3.30.0 || ^4.0.0"
+    "svelte": "^5.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.1.0",

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -1,4 +1,6 @@
 <script context="module">
+  import { mount } from 'svelte';
+
   /**
    * @typedef {typeof import('svelte').SvelteComponent | typeof import('svelte').SvelteComponent<any>} Component
    * @typedef {import('svelte/types/runtime/transition').BlurParams} BlurParams
@@ -22,12 +24,13 @@
    */
   export function bind(Component, props = {}) {
     return function ModalComponent(options) {
-      return new Component({
+      return mount(Component, {
         ...options,
         props: {
           ...props,
           ...options.props,
         },
+        target: options.parentNode,
       });
     };
   }

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -548,7 +548,7 @@
   }
 
   @supports (-webkit-touch-callout: none) {
-    body {
+    :global(body) {
       /* The hack for Safari iOS */
       height: -webkit-fill-available;
     }


### PR DESCRIPTION
## Background
I recently upgraded my repo (a plain Svelte app) to Svelte v5 and noticed some warnings and errors from `svelte-simple-modal`. I noticed the following warning from my compiler (webpack, fwiw):  
```
element_invalid_self_closing_tag: Self-closing HTML tags for non-void elements are ambiguous — 
use `<button ...></button>` rather than `<button ... />`
```
I also experienced the same issues with the modal not correctly mounting that were detailed in [this thread](https://github.com/flekschas/svelte-simple-modal/issues/113#issuecomment-2151825179).

## About
This PR fixes the following: 
* Error - Issue mounting component. Svelte 5 components are functions, not classes, and are initialised differently. The [migration guide](https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes) recommends updating to use the new `mount` function, which is what I've done in this PR.

* Warning - Self-closing HTML. Svelte 5 begins to warn about self-closing HTML. This thread has some great context about the reasoning why: https://github.com/sveltejs/svelte/issues/11052

This is unfortunately a breaking change. These changes are not backwards compatible with Svelte 3 or 4. 
