### PR TITLE
doc: fix deprecated reference to rollup-plugin-node-resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ npm install --save svelte-simple-modal
 
 #### Rollup Setup
 
-Make sure that the main application's version of `svelte` is used for bundling by setting `rollup-plugin-node-resolve`'s `dedupe` option as follows:
+Make sure that the main application's version of `svelte` is used for bundling by setting `@rollup/plugin-node-resolve`'s `dedupe` option as follows:
 
 ```js
-import resolve from 'rollup-plugin-node-resolve';
+import resolve from '@rollup/plugin-node-resolve';
 
 export default {
   plugins: [


### PR DESCRIPTION
## Background

Hi!

In the "Rollup Setup" section of the README, there is a reference to the deprecated `rollup-plugin-node-resolve` package, which has been superseded by `@rollup/plugin-node-resolve`

This is the only place where the deprecated package is mentioned, in all other places in the repo, `@rollup/plugin-node-resolve` is used

## Currently Observed Behavior

npm deprecation warning:

![image](https://github.com/user-attachments/assets/a427c09c-95fb-4d9f-84bb-97ea2927be31)

Following the steps in the README with the deprecated package, and then trying to build a sample svelte application fails with:

![image](https://github.com/user-attachments/assets/0e6de3e4-378c-4577-b322-304f002114f7)

## New Behavior

build runs successfully after switching to `@rollup/plugin-node-resolve`


